### PR TITLE
Expose AddDataPoint on MetricWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,28 +267,40 @@ Please note that:
 
     ```cs
     using com.signalfuse.metrics.protobuf;
+    ...
+    log.Info("C# HTTP trigger function processed a request.");
+    MetricWrapper wrapper = new MetricWrapper(context);
+    try { 
+        ...
+        // construct a data point
+        DataPoint dp = new DataPoint();
     
-    // construct a data point
-    DataPoint dp = new DataPoint();
+        // use Datum to set the value
+        Datum datum = new Datum();
+        datum.intValue = 1;
     
-    // use Datum to set the value
-    Datum datum = new Datum();
-    datum.intValue = 1;
+        // set the name, value, and metric type on the datapoint
     
-    // set the name, value, and metric type on the datapoint
+        dp.metric = "metric_name";
+        dp.metricType = MetricType.GAUGE;
+        dp.value = datum;
     
-    dp.metric = "metric_name";
-    dp.metricType = MetricType.GAUGE;
-    dp.value = datum;
+        // add custom dimension
+        Dimension dim = new Dimension();
+        dim.key = "applicationName";
+        dim.value = "CoolApp";
+        dp.dimensions.Add(dim);
     
-    // add custom dimension
-    Dimension dim = new Dimension();
-    dim.key = "applicationName";
-    dim.value = "CoolApp";
-    dp.dimensions.Add(dim);
-    
-    // send the metric
-    MetricSender.sendMetric(dp);
+        // send the metric
+        // on version 3.0.1 and above use wrapper.AddDataPoint(dp);
+        MetricSender.sendMetric(dp);
+        ...
+        return ResponseObject
+    } catch (Exception e) {
+      wrapper.Error();
+    } finally {
+      wrapper.Dispose();
+    }
     ```
 
 2. Review the following example to understand how to send custom metrics in the Web API Controller Layer on down for `ASP.Net Core Web API with Lambda` implementations when the Lambda context object is **not** available. In short, the SignalFx C# Lambda Wrapper provides a `SignalFx.LambdaWrapper.AspNetCoreServer.Extensions.AddMetricDataPoint()` extension method for  `Microsoft.AspNetCoreServer.Http.HttpResponse` type to export metric datapoints to SignalFx. 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The Lambda wrapper adds the following dimensions to all data points sent to Sign
 | aws_function_qualifier  | AWS Function Version Qualifier (version or version alias if it is not an event source mapping Lambda invocation) |
 | event_source_mappings  | AWS Function Name (if it is an event source mapping Lambda invocation) |
 | aws_execution_env  | AWS execution environment (e.g. AWS_Lambda_dotnetcore3.1) |
-| function_wrapper_version  | SignalFx function wrapper qualifier (e.g. signalfx_lambda_3.0.0.0) |
+| function_wrapper_version  | SignalFx function wrapper qualifier (e.g. signalfx_lambda_3.0.1.0) |
 | metric_source | The literal value of 'lambda_wrapper' |
 
 ### Tags sent by the tracing wrapper 
@@ -173,7 +173,7 @@ The tracing wrapper creates a span for the wrapper handler. This span contains t
 | aws_function_qualifier | AWS function version qualifier (version or version alias if it is not an event source mapping Lambda invocation) |
 | event_source_mappings | AWS function name (if it is an event source mapping Lambda invocation) |
 | aws_execution_env | AWS execution environment (e.g., AWS_Lambda_dotnetcore3.1) |
-| function_wrapper_version | SignalFx function wrapper qualifier (e.g., ignalfx_lambda_3.0.0.0) |
+| function_wrapper_version | SignalFx function wrapper qualifier (e.g., ignalfx_lambda_3.0.1.0) |
 | component | The literal value of 'dotnet-lambda-wrapper |
 
 ### Adding extra tags and enriching traces

--- a/src/SignalFx.LambdaWrapper/MetricWrapper.cs
+++ b/src/SignalFx.LambdaWrapper/MetricWrapper.cs
@@ -49,6 +49,12 @@ namespace SignalFx.LambdaWrapper
         {
         }
 
+        public void AddDataPoint(DataPoint dataPoint)
+        {
+            dataPoint.dimensions.AddRange(_defaultDimensions);
+            _metricsBatch.Add(dataPoint);
+        }
+
         internal MetricWrapper(List<KeyValuePair<string, string>> commonTags, ISignalFxReporter reporter = null)
         {
             _defaultDimensions = GetDefaultDimensions(commonTags);

--- a/src/SignalFx.LambdaWrapper/SignalFx.LambdaWrapper.csproj
+++ b/src/SignalFx.LambdaWrapper/SignalFx.LambdaWrapper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Version>3.0.1-rc.0</Version>
+        <Version>3.0.1.0</Version>
         <AssemblyVersion>3.0.1</AssemblyVersion>
         <Title>SignalFx AWS Lambda Wrapper C#</Title>
         <Company>SignalFx</Company>

--- a/src/SignalFx.LambdaWrapper/SignalFx.LambdaWrapper.csproj
+++ b/src/SignalFx.LambdaWrapper/SignalFx.LambdaWrapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Version>3.0.0.0</Version>
-        <AssemblyVersion>3.0.0</AssemblyVersion>
+        <Version>3.0.1-rc.0</Version>
+        <AssemblyVersion>3.0.1</AssemblyVersion>
         <Title>SignalFx AWS Lambda Wrapper C#</Title>
         <Company>SignalFx</Company>
         <Authors>SignalFx</Authors>

--- a/test/SampleLambdaFunctions.Tests/FunctionTest.cs
+++ b/test/SampleLambdaFunctions.Tests/FunctionTest.cs
@@ -180,7 +180,7 @@ namespace SampleLambdaFunctions.Tests
                 { "aws_function_name", "sample-lambda-functions" },
                 { "aws_function_version", "$LATEST" },
                 { "aws_execution_env", LambdaEnvVarFixture.ExecutionEnvironment },
-                { "function_wrapper_version", "signalfx_lambda_3.0.0.0" },
+                { "function_wrapper_version", "signalfx_lambda_3.0.1.0" },
                 { "component", "dotnet-lambda-wrapper" },
                 { "span.kind", "server" },
             };

--- a/test/SignalFx.LambdaWrapper.Tests/ExtensionsTests.cs
+++ b/test/SignalFx.LambdaWrapper.Tests/ExtensionsTests.cs
@@ -76,7 +76,7 @@ namespace SignalFx.LambdaWrapper.Tests
                 { "aws_region", "us-west-2" },
                 { "aws_account_id", "123456789012" },
                 { "lambda_arn", $"{context.InvokedFunctionArn}:{context.FunctionVersion}" },
-                { "function_wrapper_version", "signalfx_lambda_3.0.0.0" },
+                { "function_wrapper_version", "signalfx_lambda_3.0.1.0" },
                 { "metric_source", "lambda_wrapper" },
                 { "test", "extensions" },
             };

--- a/test/SignalFx.LambdaWrapper.Tests/MetricWrapperTests.cs
+++ b/test/SignalFx.LambdaWrapper.Tests/MetricWrapperTests.cs
@@ -56,7 +56,7 @@ namespace SignalFx.LambdaWrapper.Tests
                 { "aws_region", "us-west-2" },
                 { "aws_account_id", "123456789012" },
                 { "lambda_arn", "arn:aws:lambda:us-west-2:123456789012:function:sample-lambda-functions:$LATEST" }, //
-                { "function_wrapper_version", "signalfx_lambda_3.0.0.0" },
+                { "function_wrapper_version", "signalfx_lambda_3.0.1.0" },
                 { "metric_source", "lambda_wrapper" },
             };
 

--- a/test/SignalFx.LambdaWrapper.Tests/MetricWrapperTests.cs
+++ b/test/SignalFx.LambdaWrapper.Tests/MetricWrapperTests.cs
@@ -25,6 +25,14 @@ namespace SignalFx.LambdaWrapper.Tests
 
             using (var wrapper = new MetricWrapper(context, mockSender.Object))
             {
+                // Add a custom data point.
+                DataPoint dp = new DataPoint();
+                dp.metric = "custom.gauge";
+                dp.metricType = MetricType.GAUGE;
+                dp.value = new Datum { intValue = 1 };
+                dp.timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                wrapper.AddDataPoint(dp);
+
                 try
                 {
                     if (throwException)
@@ -64,6 +72,7 @@ namespace SignalFx.LambdaWrapper.Tests
             {
                 new { Name = "function.invocations", MetricType = MetricType.COUNTER },
                 new { Name = "function.duration", MetricType = MetricType.GAUGE },
+                new { Name = "custom.gauge", MetricType = MetricType.GAUGE },
             };
 
             if (throwException)


### PR DESCRIPTION
The goal is to allow e2e validation tests when generating a new layer.

Previously there was a static method  `MetricSender.sendMetric` that exposed this capability. However, it required a metric wrapper to work correctly which is confusing from an API usage point. This change adds an `AddDataPoint` method to the wrapper to support the same functionality. If the user needs access to the method without passing the wrapper they can directly set a static reference to it.