### PR TITLE
Automate nu get package release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
           name: Copy NuGet packages to artifacts directory
           command: |
             mkdir artifacts
-            cp -r bin/package/. artifacts/
+            xcopy bin/package artifacts/ /E
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,15 @@ commands:
           name: Build NuGet Package
           command: dotnet pack src/SignalFx.LambdaWrapper/SignalFx.LambdaWrapper.csproj -c Release -o bin/package 
 
+  copy_nuget_for_release:
+    steps:
+      - run:
+          name: Create artifacts directory
+          command: mkdir artifacts
+      - run:
+          name: Copy NuGet packages to artifacts directory
+          command: cp -a bin/package/. artifacts/
+
 jobs:
   Linux:
     machine:
@@ -59,17 +68,48 @@ jobs:
     executor: 
       name: win/default
       shell: cmd.exe
-
     steps:
       - build
       - test
       - build_nuget
+      - copy_nuget_for_release
       - store_artifacts:
-          path: C:\Users\circleci\project\bin\package\
+          path: artifacts
+      - persist_to_workspace:
+          root: .
+          paths:
+              - artifacts
+
+  PublishNuGetPackages:
+    docker:
+      - image: mcr.microsoft.com/dotnet/sdk:5.0
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish NuGet Packages
+          command: |
+            for i in ./artifacts/*.nupkg; do dotnet nuget push $i --source "${NUGET_FEED_URL}" --api-key ${NUGET_KEY}; done
 
 workflows:
   version: 2
   build:
     jobs:
-      - Linux
-      - Windows
+      - Linux:
+          filters:
+            tags:
+              only: /.*/ # this assures that the step will be run when the tag is pushed
+      - Windows:
+          filters:
+            tags:
+              only: /.*/
+      - PublishNuGetPackages:
+          requires:
+            - Linux
+            - Windows
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ commands:
       - run:
           name: Copy NuGet packages to artifacts directory
           command: |
-            mkdir -p artifacts
-            cp -a bin/package/. artifacts/
+            mkdir artifacts
+            cp -r bin/package/* artifacts
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
           name: Copy NuGet packages to artifacts directory
           command: |
             mkdir artifacts
-            cp -r bin/package/* artifacts
+            cp -r bin/package/. artifacts/
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
           name: Copy NuGet packages to artifacts directory
           command: |
             mkdir artifacts
-            xcopy bin/package artifacts/ /E
+            xcopy bin\package artifacts\ /E
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: "Publish Release on GitHub"
+          name: Publish Release on GitHub
           command: |
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,10 @@ commands:
   copy_nuget_for_release:
     steps:
       - run:
-          name: Create artifacts directory
-          command: mkdir artifacts
-      - run:
           name: Copy NuGet packages to artifacts directory
-          command: cp -a bin/package/. artifacts/
+          command: |
+            mkdir -p artifacts
+            cp -a bin/package/. artifacts/
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,7 @@ commands:
     steps:
       - run:
           name: Copy NuGet packages to artifacts directory
-          command: |
-            mkdir artifacts
-            xcopy bin\package artifacts\ /E
+          command: cp -a bin/package/. artifacts/
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,17 @@ jobs:
           paths:
               - artifacts
 
+  PublishGitHubRelease:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/
+
   PublishNuGetPackages:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:5.0
@@ -103,6 +114,15 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - PublishGitHubRelease:
+          requires:
+            - Linux
+            - Windows
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
       - PublishNuGetPackages:
           requires:
             - Linux


### PR DESCRIPTION
Adding release automation to our CircleCI pipeline. Pushing tag should trigger the build that will add release assets and publish NuGet Packages.

To make it work we have to provide following environment variables to the CircleCI:
GITHUB_TOKEN - personal GitHub token
NUGET_KEY - api key for accessing nuget.org
NUGET_FEED_URL - nuget.org feed